### PR TITLE
:sparkles: reafctoring MapComponents

### DIFF
--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -1,86 +1,41 @@
 import * as React from 'react';
 import { View, StyleSheet, Dimensions } from 'react-native';
 import MapViewComponent from './mapComponents/MapViewComponent';
+import { MovieMarker, ToiletMarker, ElevatorMarker, GuideLine, Region } from '../domains/map';
 
 interface Props {
   indoorLevel: string;
-  initializedLocation: InitializedLocation;
-  movieMarkers?: MovieMarkers[];
+  initializedLocation: Region;
+  movieMarkers?: MovieMarker[];
   toiletMarkers?: ToiletMarker[];
   elevatorMarkers?: ElevatorMarker[];
-  guideLines: guideLines[];
+  guideLines: GuideLine[];
   currentScreen: string;
   screenChange: any;
   changeIndoorLevel: any;
 }
 
-interface MovieMarkers {
-  floor: string;
-  movieId: number;
-  latitude: number;
-  longitude: number;
-}
+export const MainWindow: React.SFC<Props> = props => {
+  const mapScreen = () => (
+    <MapViewComponent
+      indoorLevel={props.indoorLevel}
+      initializedLocation={props.initializedLocation}
+      movieMarkers={props.movieMarkers}
+      toiletMarkers={props.toiletMarkers}
+      elevatorMarkers={props.elevatorMarkers}
+      guideLines={props.guideLines}
+      changeIndoorLevel={props.changeIndoorLevel}
+    />
+  );
 
-interface ToiletMarker {
-  floor: string;
-  latitude: number;
-  longitude: number;
-}
+  const videoScreen = () => (<View style={style.container} />);
 
-interface ElevatorMarker {
-  floor: string;
-  capacity: 6 | 12;
-  latitude: number;
-  longitude: number;
-}
-
-interface InitializedLocation {
-  latitude: number;
-  longitude: number;
-  latitudeDelta: number;
-  longitudeDelta: number;
-}
-
-interface guideLines {
-    floor: string;
-    latitude: number;
-    longitude: number;
-  }
-
-export default class SubWindow extends React.Component<Props, {}> {
-  constructor(props: Props) {
-    super(props);
-  }
-
-  public render() {
-    const currentScreen = this.props.currentScreen === 'map' ? this.mapScreen() : this.videoScreen();
-    return (
-      <View style={style.container}>
-        {currentScreen}
-      </View>
-    );
-  }
-
-  private mapScreen() {
-    return (
-      <MapViewComponent
-        indoorLevel={this.props.indoorLevel}
-        initializedLocation={this.props.initializedLocation}
-        movieMarkers={this.props.movieMarkers}
-        toiletMarkers={this.props.toiletMarkers}
-        elevatorMarkers={this.props.elevatorMarkers}
-        guideLines={this.props.guideLines}
-        changeIndoorLevel={this.props.changeIndoorLevel}
-      />
-    );
-  }
-
-  private videoScreen() {
-    return (
-      <View style={style.container}></View>
-    );
-  }
-}
+  return (
+    <View style={style.container}>
+      {props.currentScreen === 'map' ? mapScreen() : videoScreen()}
+    </View>
+  );
+};
 
 const {width, height} = Dimensions.get('screen');
 

--- a/src/components/SubWindow.tsx
+++ b/src/components/SubWindow.tsx
@@ -1,39 +1,22 @@
 import * as React from 'react';
 import { View, StyleSheet, TouchableOpacity } from 'react-native';
 import MapViewComponent from './mapComponents/MapViewComponent';
+import { GuideLine, Region } from 'src/domains/map';
 
 interface Props {
   indoorLevel: string;
-  initializedLocation: InitializedLocation;
-  guideLines: guideLines[];
+  initializedLocation: Region;
+  guideLines: GuideLine[];
   currentScreen: 'video' | 'map';
   screenChange: any;
   changeIndoorLevel: any;
 }
 
-interface InitializedLocation {
-  latitude: number;
-  longitude: number;
-  latitudeDelta: number;
-  longitudeDelta: number;
-}
-
-interface guideLines {
-  floor: string;
-  latitude: number;
-  longitude: number;
-}
-
 export default class SubWindow extends React.Component<Props, {}> {
-  constructor(props: Props) {
-    super(props);
-  }
-
   public render() {
-    const currentScreen = this.props.currentScreen === 'video' ? this.mapScreen() : this.videoScreen();
     return (
       <View style={style.container}>
-        {currentScreen}
+        {this.props.currentScreen === 'video' ? this.mapScreen() : this.videoScreen()}
       </View>
     );
   }

--- a/src/components/mapComponents/MapViewComponent.tsx
+++ b/src/components/mapComponents/MapViewComponent.tsx
@@ -4,14 +4,15 @@ import MapView, { PROVIDER_GOOGLE } from 'react-native-maps';
 import MarkerComponent from './MarkerComponent';
 import PolylineComponent from './PolylineComponent';
 import CustomMap from '../mapComponents/CustomMap';
+import { MovieMarker, ToiletMarker, ElevatorMarker, GuideLine, Region} from '../../domains/map';
 
 interface Props {
   indoorLevel: string;
-  initializedLocation: InitializedLocation;
-  movieMarkers?: MovieMarkers[];
+  initializedLocation: Region;
+  movieMarkers?: MovieMarker[];
   toiletMarkers?: ToiletMarker[];
   elevatorMarkers?: ElevatorMarker[];
-  guideLines?: guideLines[];
+  guideLines?: GuideLine[];
   guideLinesColor?: string;
   changeIndoorLevel: any;
   screenChange?: any;
@@ -19,58 +20,15 @@ interface Props {
 }
 
 interface State {
-  initializedLocation: InitializedLocation;
-}
-
-interface Region {
-  latitude: number;
-  longitude: number;
-  latitudeDelta: number;
-  longitudeDelta: number;
-}
-
-interface MovieMarkers {
-  floor: string;
-  movieId: number;
-  latitude: number;
-  longitude: number;
-}
-
-interface ToiletMarker {
-  floor: string;
-  latitude: number;
-  longitude: number;
-}
-
-interface ElevatorMarker {
-  floor: string;
-  capacity: 6 | 12;
-  latitude: number;
-  longitude: number;
-}
-
-interface InitializedLocation {
-  latitude: number;
-  longitude: number;
-  latitudeDelta: number;
-  longitudeDelta: number;
-}
-
-interface guideLines {
-  floor: string;
-  latitude: number;
-  longitude: number;
+  initializedLocation: Region;
 }
 
 export default class MapViewComponent extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      initializedLocation: this.props.initializedLocation,
-    };
-  }
+  readonly state = {
+    initializedLocation: this.props.initializedLocation,
+  };
 
-  public shouldComponentUpdate(nextProps: Props, nextState: State) {
+  public shouldComponentUpdate(nextProps: Props, _: State) {
     return this.props.indoorLevel === nextProps.indoorLevel ? false : true;
   }
 

--- a/src/components/mapComponents/MarkerComponent.tsx
+++ b/src/components/mapComponents/MarkerComponent.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Marker } from 'react-native-maps';
+import { MovieMarker, ToiletMarker, ElevatorMarker }from '../../domains/map';
 
 interface Props {
   indoorLevel: string;
@@ -15,26 +16,6 @@ interface State {
   currentMovieMarkers?: MovieMarker[];
   currentToiletMarkers?: ToiletMarker[];
   currentElevatorMarkers?: ElevatorMarker[];
-}
-
-interface MovieMarker {
-  floor: string;
-  movieId: number;
-  latitude: number;
-  longitude: number;
-}
-
-interface ToiletMarker {
-  floor: string;
-  latitude: number;
-  longitude: number;
-}
-
-interface ElevatorMarker {
-  floor: string;
-  capacity: 6 | 12;
-  latitude: number;
-  longitude: number;
 }
 
 export default class MarkerComponent extends React.Component<Props, State> {

--- a/src/components/mapComponents/PolylineComponent.tsx
+++ b/src/components/mapComponents/PolylineComponent.tsx
@@ -1,32 +1,25 @@
 import * as React from 'react';
 import { Polyline } from 'react-native-maps';
 import Colors from '../../constants/Colors';
+import { GuideLine } from '../../domains/map';
 
 interface Props {
   indoorLevel: string;
-  guideLines:guideLines[];
+  guideLines: GuideLine[];
   guideLinesColor?: string;
 }
 
 interface State {
   indoorLevel: string;
-  guideLines: guideLines[];
+  guideLines: GuideLine[];
 }
 
-interface guideLines {
-  floor: string;
-    latitude: number;
-    longitude: number;
-}
 
 export default class PolylineComponent extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      indoorLevel: this.props.indoorLevel,
-      guideLines: this.props.guideLines,
-    };
-  }
+  readonly state = {
+    indoorLevel: this.props.indoorLevel,
+    guideLines: this.props.guideLines,
+  };
 
   public componentWillReceiveProps(nextProps: Props) {
     this.setState({

--- a/src/domains/map.ts
+++ b/src/domains/map.ts
@@ -1,0 +1,33 @@
+export interface MovieMarker {
+  floor: string;
+  movieId: number;
+  latitude: number;
+  longitude: number;
+}
+
+export interface ToiletMarker {
+  floor: string;
+  latitude: number;
+  longitude: number;
+}
+
+type ElevatorCapacity = 6 | 12;
+export interface ElevatorMarker {
+  floor: string;
+  capacity: ElevatorCapacity;
+  latitude: number;
+  longitude: number;
+}
+
+export interface GuideLine {
+  floor: string;
+  latitude: number;
+  longitude: number;
+}
+
+export interface Region {
+  latitude: number;
+  longitude: number;
+  latitudeDelta: number;
+  longitudeDelta: number;
+}

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -1,60 +1,25 @@
 import * as React from 'react';
-import { StyleSheet, View, Dimensions } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import SubWindow from '../components/SubWindow';
-import MainWindow from '../components/MainWindow';
+import { MainWindow } from '../components/MainWindow';
+import { Region, MovieMarker, ToiletMarker, ElevatorMarker, GuideLine } from 'src/domains/map';
 
 interface State {
   indoorLevel: string;
   currentScreen: 'video' | 'map';
-  initializedLocation: InitializedLocation;
-  movieMarkers?: MovieMarkers[];
+  initializedLocation: Region;
+  movieMarkers?: MovieMarker[];
   toiletMarkers?: ToiletMarker[];
   elevatorMarkers?: ElevatorMarker[];
-  guideLines: guideLines[];
+  guideLines: GuideLine[];
 }
-
-interface MovieMarkers {
-  floor: string;
-  movieId: number;
-  latitude: number;
-  longitude: number;
-}
-
-interface ToiletMarker {
-  floor: string;
-  latitude: number;
-  longitude: number;
-}
-
-interface ElevatorMarker {
-  floor: string;
-  capacity: 6 | 12;
-  latitude: number;
-  longitude: number;
-}
-
-interface InitializedLocation {
-  latitude: number;
-  longitude: number;
-  latitudeDelta: number;
-  longitudeDelta: number;
-}
-
-interface guideLines {
-    floor: string;
-    latitude: number;
-    longitude: number;
-  }
-
 
 export default class MapScreen extends React.Component<{}, State> {
   public static navigationOptions = {
-    headerStyle: {
-      display: 'none',
-    },
+    headerStyle: { display: 'none' },
   };
 
-  constructor(props) {
+  constructor(props: {}) {
     super(props);
     this.state = {
       indoorLevel: '1',
@@ -247,17 +212,13 @@ export default class MapScreen extends React.Component<{}, State> {
   }
 
   private screenChange(currentScreen: 'video' | 'map') {
-    this.setState({
-      currentScreen: currentScreen,
-    });
+    this.setState({ currentScreen: currentScreen });
   }
 
   private changeIndoorLevel(indoorLevel: string) {
     const validatedIndoorLevel = indoorLevel.replace(/階/, '');
     const currentFloor = validatedIndoorLevel.substr(-2);
-    this.setState({
-      indoorLevel: currentFloor,
-    });
+    this.setState({ indoorLevel: currentFloor });
   }
 }
 


### PR DESCRIPTION
# やったこと

- Domain層にinteface宣言を統一
- 既存のinterfaceを↑に置き換え（同時に命名規則の統一）
- SFCを使うように書き換え
- readOnly宣言でStateの初期化するように
- そのほかちょっとしたリファクタ